### PR TITLE
feature: 드래그앤드랍으로 순서바꾸기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -35,6 +36,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -121,6 +134,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -846,7 +876,7 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -861,6 +891,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.24.0",
@@ -1712,6 +1748,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1729,7 +1774,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4584,6 +4629,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
@@ -4612,6 +4663,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4635,6 +4709,12 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4657,6 +4737,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -5523,6 +5609,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
@@ -5769,6 +5861,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "next": "15.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/components/board/BoardItem.tsx
+++ b/src/app/components/board/BoardItem.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export function BoardItem({ id, index, title }: Props) {
-  const { editBoard, removeBoard } = useTodoContext();
+  const { list, changeSelectedBoard, editBoard, removeBoard } = useTodoContext();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const [isEditable, setEditable] = useState(false);
@@ -50,6 +50,7 @@ export function BoardItem({ id, index, title }: Props) {
             {(draggableProvided) => (
               <li
                 className={style.item}
+                onClick={() => changeSelectedBoard(list, id)}
                 ref={draggableProvided.innerRef}
                 {...draggableProvided.draggableProps}
                 {...draggableProvided.dragHandleProps}>

--- a/src/app/components/board/BoardItem.tsx
+++ b/src/app/components/board/BoardItem.tsx
@@ -1,18 +1,21 @@
+import { Draggable, Droppable } from "@hello-pangea/dnd";
 import { useEffect, useRef, useState } from "react";
 
 import { Bars } from "@/app/assets/icons/Bars";
 import { Edit } from "@/app/assets/icons/Edit";
 import { Trash } from "@/app/assets/icons/Trash";
 import { useTodoContext } from "@/app/context/TodoContext";
+import { formatBoardName } from "@/app/utils/dnd.utils";
 import { Input } from "../common/Input";
 import { BoardProps } from "./board.interface";
 
 interface Props {
   id: BoardProps['id'];
+  index: number;
   title: BoardProps['title'];
 }
 
-export function BoardItem({ id, title }: Props) {
+export function BoardItem({ id, index, title }: Props) {
   const { editBoard, removeBoard } = useTodoContext();
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -33,38 +36,60 @@ export function BoardItem({ id, title }: Props) {
   }, [isEditable]);
 
   return (
-    <li
-      className={style.item}>
-      <Bars className={style.icon.common} />
+    <Droppable
+      droppableId={formatBoardName(id)}
+      isCombineEnabled>
+      {(droppableProvided) => (
+        <div
+          ref={droppableProvided.innerRef}
+          {...droppableProvided.droppableProps}>
+          <Draggable
+            key={id}
+            draggableId={id}
+            index={index}>
+            {(draggableProvided) => (
+              <li
+                className={style.item}
+                ref={draggableProvided.innerRef}
+                {...draggableProvided.draggableProps}
+                {...draggableProvided.dragHandleProps}>
+                <Bars className={style.icon.common} />
 
-      <div
-        className={style.content.wrapper}>
-        {isEditable ? (
-          <Input
-            allowClear={false}
-            className={style.content.input}
-            defaultValue={title}
-            ref={inputRef} />
-        ) : (
-          <span className={style.content.span}>
-            {title}
-          </span>
-        )}
-      </div>
+                <div
+                  className={style.content.wrapper}>
+                  {isEditable ? (
+                    <Input
+                      allowClear={false}
+                      className={style.content.input}
+                      defaultValue={title}
+                      ref={inputRef} />
+                  ) : (
+                    <span className={style.content.span}>
+                      {title}
+                    </span>
+                  )}
+                </div>
 
-      <div className={style.buttons.wrapper}>
-        <button onClick={() => setEditable(true)} >
-          <Edit className={`${style.icon.common} ${style.icon.edit}`} />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            removeBoard(id);
-          }}>
-          <Trash className={`${style.icon.common} ${style.icon.remove}`} />
-        </button>
-      </div>
-    </li>
+                <div className={style.buttons.wrapper}>
+                  <button onClick={() => setEditable(true)} >
+                    <Edit className={`${style.icon.common} ${style.icon.edit}`} />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeBoard(id);
+                    }}>
+                    <Trash className={`${style.icon.common} ${style.icon.remove}`} />
+                  </button>
+                </div>
+              </li>
+            )}
+          </Draggable >
+          {droppableProvided.placeholder}
+        </div>
+      )
+      }
+    </Droppable >
   );
 }
 

--- a/src/app/components/board/BoardList.tsx
+++ b/src/app/components/board/BoardList.tsx
@@ -7,10 +7,11 @@ export function BoardList() {
   return (
     <ul className={style.list} >
       {list.length > 0 ? (
-        list.map((board) => (
+        list.map((board, index) => (
           <BoardItem
             key={board.id}
             id={board.id}
+            index={index}
             title={board.title} />
         ))) : (
         <li className={style.empty}>

--- a/src/app/components/todo/TodoItem.tsx
+++ b/src/app/components/todo/TodoItem.tsx
@@ -1,4 +1,4 @@
-import { Draggable } from "@hello-pangea/dnd";
+import { Draggable, DraggableStateSnapshot, DraggableStyle } from "@hello-pangea/dnd";
 import { useEffect, useRef, useState } from "react";
 
 import { Bars } from "@/app/assets/icons/Bars";
@@ -33,17 +33,29 @@ export function TodoItem({ id, content, index }: Props) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isEditable]);
 
+  function getStyle(style: DraggableStyle = {}, snapshot: DraggableStateSnapshot) {
+    if (!snapshot.combineWith) {
+      return style;
+    }
+    return {
+      ...style,
+      backgroundColor: '#eff6ff',
+      transition: `all 0.1s`,
+    };
+  }
+
   return (
     <Draggable
       key={id}
       draggableId={id}
       index={index}>
-      {(provided) => (
+      {(provided, snapshot) => (
         <li
           className={style.item}
           ref={provided.innerRef}
           {...provided.draggableProps}
-          {...provided.dragHandleProps}>
+          {...provided.dragHandleProps}
+          style={getStyle(provided.draggableProps.style, snapshot)}>
           <Bars className={style.icon.common} />
 
           <div className={style.content.wrapper}>

--- a/src/app/components/todo/TodoItem.tsx
+++ b/src/app/components/todo/TodoItem.tsx
@@ -1,19 +1,20 @@
+import { Draggable } from "@hello-pangea/dnd";
 import { useEffect, useRef, useState } from "react";
 
 import { Bars } from "@/app/assets/icons/Bars";
 import { Edit } from "@/app/assets/icons/Edit";
 import { Trash } from "@/app/assets/icons/Trash";
-import { Input } from "../common/Input";
 import { useTodoContext } from "@/app/context/TodoContext";
+import { Input } from "../common/Input";
 import { TodoItemProps } from "./todo.interface";
 
-interface Props {
-  id: TodoItemProps['id'];
-  content: string;
+interface Props extends TodoItemProps {
+  index: number;
 }
 
-export function TodoItem({ id, content }: Props) {
+export function TodoItem({ id, content, index }: Props) {
   const { editTodo, removeTodo } = useTodoContext();
+
   const inputRef = useRef<HTMLInputElement>(null);
   const [isEditable, setEditable] = useState(false);
 
@@ -33,32 +34,43 @@ export function TodoItem({ id, content }: Props) {
   }, [isEditable]);
 
   return (
-    <li className={style.item}>
-      <Bars className={style.icon.common} />
+    <Draggable
+      key={id}
+      draggableId={id}
+      index={index}>
+      {(provided) => (
+        <li
+          className={style.item}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}>
+          <Bars className={style.icon.common} />
 
-      <div className={style.content.wrapper}>
-        {isEditable ? (
-          <Input
-            allowClear={false}
-            className={style.content.input}
-            defaultValue={content}
-            ref={inputRef} />
-        ) : (
-          <span className={style.content.span}>
-            {content}
-          </span>
-        )}
-      </div>
+          <div className={style.content.wrapper}>
+            {isEditable ? (
+              <Input
+                allowClear={false}
+                className={style.content.input}
+                defaultValue={content}
+                ref={inputRef} />
+            ) : (
+              <span className={style.content.span}>
+                {content}
+              </span>
+            )}
+          </div>
 
-      <div className={style.buttons.wrapper}>
-        <button onClick={() => setEditable(true)} >
-          <Edit className={`${style.icon.common} ${style.icon.edit}`} />
-        </button>
-        <button onClick={() => removeTodo(id)} >
-          <Trash className={`${style.icon.common} ${style.icon.remove}`} />
-        </button>
-      </div>
-    </li>
+          <div className={style.buttons.wrapper}>
+            <button onClick={() => setEditable(true)} >
+              <Edit className={`${style.icon.common} ${style.icon.edit}`} />
+            </button>
+            <button onClick={() => removeTodo(id)} >
+              <Trash className={`${style.icon.common} ${style.icon.remove}`} />
+            </button>
+          </div>
+        </li>
+      )}
+    </Draggable >
   );
 }
 

--- a/src/app/components/todo/TodoList.tsx
+++ b/src/app/components/todo/TodoList.tsx
@@ -1,3 +1,5 @@
+import { Droppable } from "@hello-pangea/dnd";
+
 import { useTodoContext } from "@/app/context/TodoContext";
 import { TodoItem } from "./TodoItem";
 
@@ -5,13 +7,25 @@ export function TodoList() {
   const { selectedBoard } = useTodoContext();
 
   return (
-    <ul className={style.list}>
-      {(selectedBoard?.items ?? []).map((todo) => (
-        <TodoItem
-          key={todo.id}
-          {...todo} />
-      ))}
-    </ul>
+    <Droppable
+      // 이 컴포넌트 부모(TodoBoard)에서 selectedBoard로 분기쳐서 UI 그리고 있음
+      droppableId={selectedBoard!.id}
+      isCombineEnabled>
+      {(provided) => (
+        <ul
+          className={style.list}
+          ref={provided.innerRef}
+          {...provided.droppableProps}>
+          {(selectedBoard?.items ?? []).map((todo, index) => (
+            <TodoItem
+              key={todo.id}
+              index={index}
+              {...todo} />
+          ))}
+          {provided.placeholder}
+        </ul>
+      )}
+    </Droppable >
   );
 }
 

--- a/src/app/context/TodoContext.tsx
+++ b/src/app/context/TodoContext.tsx
@@ -211,6 +211,7 @@ const useTodo = () => {
     addTodo,
     editTodo,
     removeTodo,
+    changeSelectedBoard,
     reorderOnDragEnd,
   };
 };

--- a/src/app/context/TodoContext.tsx
+++ b/src/app/context/TodoContext.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BoardProps } from '../components/board/board.interface';
 import { TodoItemProps } from '../components/todo/todo.interface';
+import { DropResult } from '@hello-pangea/dnd';
 
 const TodoContext = createContext<ReturnType<typeof useTodo> | null>(null);
 
@@ -131,6 +132,11 @@ const useTodo = () => {
     saveSelectedBoard(newList);
   };
 
+  /* -------------------- drag & drop -------------------- */
+  const reorderOnDragEnd = (result: DropResult) => {
+    console.log(result);
+  };
+
   useEffect(() => {
     getList();
   }, []);
@@ -144,6 +150,7 @@ const useTodo = () => {
     addTodo,
     editTodo,
     removeTodo,
+    reorderOnDragEnd,
   };
 };
 

--- a/src/app/context/TodoContext.tsx
+++ b/src/app/context/TodoContext.tsx
@@ -23,6 +23,7 @@ const useTodo = () => {
     setSelectedBoard(null);
     localStorage.removeItem('list');
   };
+
   const saveList = (list: BoardProps[]) => {
     setList(list);
     saveStorage(list);
@@ -159,13 +160,34 @@ const useTodo = () => {
   }
 
   const reorderOnDragEnd = (result: DropResult) => {
-    const { source, destination } = result;
+    const { source, destination, draggableId, combine } = result;
 
     const isSourceBoard = source.droppableId.includes('board-');
     const isDestinationBoard = destination && destination?.droppableId.includes('board-');
 
+    // Todo -> Board
+    // 같은 보드끼리는 이동해도 아무런 상호작용 X
+    const isSameBoard = source.droppableId === combine?.draggableId;
+    if (combine?.droppableId.includes('board-') && !isSameBoard) {
+      const selectedTodo = selectedBoard?.items.find(todo => todo.id === draggableId);
+
+      if (selectedTodo) {
+        const newList = list.map(board => {
+          if (combine.droppableId.includes(board.id)) {
+            return { ...board, items: [...board.items, selectedTodo] };
+          } else if (board.id === source.droppableId) {
+            return { ...board, items: board.items.filter(todo => todo.id !== draggableId) };
+          } else {
+            return board;
+          }
+        });
+
+        saveList(newList);
+        saveSelectedBoard(newList);
+      }
+    }
     // Board 내에서 이동
-    if (isSourceBoard && isDestinationBoard) {
+    else if (isSourceBoard && isDestinationBoard) {
       reorderBoard(source.index, destination.index);
     }
     // Todo 내에서 이동

--- a/src/app/context/TodoContext.tsx
+++ b/src/app/context/TodoContext.tsx
@@ -1,10 +1,11 @@
 'use client';
+import { DropResult } from '@hello-pangea/dnd';
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { BoardProps } from '../components/board/board.interface';
 import { TodoItemProps } from '../components/todo/todo.interface';
-import { DropResult } from '@hello-pangea/dnd';
+import { reorderInSameList } from '../utils/dnd.utils';
 
 const TodoContext = createContext<ReturnType<typeof useTodo> | null>(null);
 
@@ -133,8 +134,37 @@ const useTodo = () => {
   };
 
   /* -------------------- drag & drop -------------------- */
+  const reorderTodo = (startIndex: number, endIndex: number) => {
+    if (!selectedBoard) return;
+
+    const newBoard = reorderInSameList({
+      list: selectedBoard.items,
+      startIndex,
+      endIndex,
+    });
+
+    const newList = list.map(board => (
+      board.id === selectedBoard.id
+        ? { ...board, items: newBoard }
+        : board
+    ));
+
+    saveList(newList);
+    saveSelectedBoard(newList);
+  }
+
   const reorderOnDragEnd = (result: DropResult) => {
-    console.log(result);
+    const { source, destination } = result;
+
+    const isSourceBoard = source.droppableId.includes('board-');
+    const isDestinationBoard = destination && destination?.droppableId.includes('board-');
+
+    // Todo 내에서 이동
+    if (!isSourceBoard && !isDestinationBoard) {
+      if (destination) {
+        reorderTodo(source.index, destination.index);
+      }
+    }
   };
 
   useEffect(() => {

--- a/src/app/context/TodoContext.tsx
+++ b/src/app/context/TodoContext.tsx
@@ -134,6 +134,11 @@ const useTodo = () => {
   };
 
   /* -------------------- drag & drop -------------------- */
+  const reorderBoard = (startIndex: number, endIndex: number) => {
+    const newList = reorderInSameList<BoardProps>({ list, startIndex, endIndex });
+    saveList(newList);
+  }
+
   const reorderTodo = (startIndex: number, endIndex: number) => {
     if (!selectedBoard) return;
 
@@ -159,8 +164,12 @@ const useTodo = () => {
     const isSourceBoard = source.droppableId.includes('board-');
     const isDestinationBoard = destination && destination?.droppableId.includes('board-');
 
+    // Board 내에서 이동
+    if (isSourceBoard && isDestinationBoard) {
+      reorderBoard(source.index, destination.index);
+    }
     // Todo 내에서 이동
-    if (!isSourceBoard && !isDestinationBoard) {
+    else if (!isSourceBoard && !isDestinationBoard) {
       if (destination) {
         reorderTodo(source.index, destination.index);
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,29 @@
 'use client';
+import { DragDropContext } from '@hello-pangea/dnd';
 import { Board } from './components/board/Board';
 import { TodoBoard } from './components/todo/TodoBoard';
+import { useTodoContext } from './context/TodoContext';
 
 export default function Home() {
+  const { selectedBoard, reorderOnDragEnd } = useTodoContext();
+
   return (
-    <main className={style.main}>
-      <Board
-        className={`
+    <DragDropContext onDragEnd={reorderOnDragEnd}>
+      <main className={style.main}>
+        <Board
+          className={`
           ${style.wrapper.common} 
           ${style.wrapper.board}
         `} />
 
-      <TodoBoard
-        className={`
-          ${style.wrapper.common} 
-          ${style.wrapper.todo}
-        `} />
-    </main >
+        <TodoBoard
+          className={`
+            ${style.wrapper.common} 
+            ${style.wrapper.todo}
+          `}
+          {...selectedBoard} />
+      </main >
+    </DragDropContext>
   );
 }
 

--- a/src/app/utils/dnd.utils.ts
+++ b/src/app/utils/dnd.utils.ts
@@ -8,3 +8,7 @@ export const reorderInSameList = <T>({ list, startIndex, endIndex }: {
   newList.splice(endIndex, 0, removed);
   return newList;
 };
+
+export const formatBoardName = (name: string): string => {
+  return 'board-' + name;
+}

--- a/src/app/utils/dnd.utils.ts
+++ b/src/app/utils/dnd.utils.ts
@@ -1,0 +1,10 @@
+export const reorderInSameList = <T>({ list, startIndex, endIndex }: {
+  list: T[];
+  startIndex: number;
+  endIndex: number;
+}): T[] => {
+  const newList = Array.from(list);
+  const [removed] = newList.splice(startIndex, 1);
+  newList.splice(endIndex, 0, removed);
+  return newList;
+};


### PR DESCRIPTION
### 카테고리
- [x] feature
- [ ] fix
- [ ] hot fix
- [ ] refact
- [ ] trivial

---

### 변경 사항
1. dnd 라이브러리 설치
2. 투두 리스트 내에서 드래그앤 드랍으로 순서 변경하는 기능 개발
  1) 리스트 전체에 Droppable 설정
  2) 개별 아이템에 Draggable 설정
3. 보드 리스트 내에서 드래그앤 드랍으로 순서 변경하는 기능 개발
  1) 개별 아이템에 Draggable, Draggable 설정
4. 투두 -> 보드
  1) 같은 구역에서 옮기면 순서 변경이지만 투두 > 보드로 옮기면 투두가 속한 보드 변경하기임
  2) 개별 아이템에 Draggable, Draggable 설정

### 상세 설명
2-2) Draggable 설정할 때 key랑 draggableId 프롭이랑 일치해야만 작동함
3-1) 투두를 보드쪽에 넣어야 할 때 Droppable을 개별로 설정하지 않으면 어떤 보드에 넣겠다는 건지 알 수가 없음
4-1) 같은 구역의 투두를 옮기려고 하면 아무 일도 일어나지 않도록 조건 추가

---

### 추가 정보
- 티켓 번호: dragAndDrop